### PR TITLE
fix to main property in bower.json for grunt-bower injection

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Ilya Gelman <ilyagelman@ilyagelman.com>"
   ],
   "description": "Simple customizable AngularJS calendar with no dependencies and timed events",
-  "main": ["dist/angular-simple-calendar.css, dist/angular-simple-calendar.js"],
+  "main": ["dist/angular-simple-calendar.css", "dist/angular-simple-calendar.js"],
   "keywords": [
     "angular",
     "angularjs",


### PR DESCRIPTION
main property set to a single string instead of an array of two strings, making injection with grunt-bower incorrect.
